### PR TITLE
Refactoring for hghs

### DIFF
--- a/BackendTranslationService.ts
+++ b/BackendTranslationService.ts
@@ -12,15 +12,12 @@ const LOG = LogService.createLogger('BackendTranslationService');
 
 export class BackendTranslationService {
 
-    public static initialize (
+    public static async initialize (
         defaultLanguage : Language,
         resources       : TranslationResourceObject
     ) : Promise<void> {
-
         const languageResources : Resource = TranslationUtils.getConfig(resources);
-
-        return new Promise((resolve, reject) => {
-
+        return await new Promise((resolve, reject) => {
             i18nInit(
                 {
                     resources: languageResources,
@@ -35,9 +32,7 @@ export class BackendTranslationService {
                 LOG.error(`Error in init: `, err);
                 reject(err);
             });
-
         });
-
     }
 
     public static async translateKeys (

--- a/EmailAuthMessageService.ts
+++ b/EmailAuthMessageService.ts
@@ -17,11 +17,23 @@ import {
 } from "./EmailService";
 import { LogService } from "../core/LogService";
 
-const LOG = LogService.createLogger('AuthEmailMessageService');
+const LOG = LogService.createLogger('EmailAuthMessageService');
 
 export class EmailAuthMessageService {
 
-    public static async sendAuthenticationCode (
+    private readonly _emailService : EmailService;
+
+    /**
+     *
+     * @param emailService
+     */
+    public constructor (
+        emailService: EmailService
+    ) {
+        this._emailService = emailService;
+    }
+
+    public async sendAuthenticationCode (
         lang: Language,
         email: string,
         code: string
@@ -49,7 +61,7 @@ export class EmailAuthMessageService {
         const contentText: string = translations[T_M_AUTH_CODE_HEADER_TEXT] + translations[T_M_AUTH_CODE_BODY_TEXT] + translations[T_M_AUTH_CODE_FOOTER_TEXT];
         const contentHtml: string = translations[T_M_AUTH_CODE_HEADER_HTML] + translations[T_M_AUTH_CODE_BODY_HTML] + translations[T_M_AUTH_CODE_FOOTER_HTML];
 
-        await EmailService.sendEmailMessage(
+        await this._emailService.sendEmailMessage(
             {
                 to: email,
                 subject,

--- a/EmailService.ts
+++ b/EmailService.ts
@@ -17,15 +17,28 @@ export interface EmailMessage {
 
 export class EmailService {
 
-    private static _from        : string | undefined;
-    private static _transporter : any | undefined;
+    private _from        : string | undefined;
+    private _transporter : any | undefined;
 
-    public static setDefaultFrom (from: string) {
+    /**
+     *
+     * @param from
+     * @param transporter
+     */
+    public constructor (
+        from         : string,
+        transporter ?: any | undefined
+    ) {
+        this._from = from;
+        this._transporter = transporter;
+    }
+
+    public setDefaultFrom (from: string) {
         this._from = from;
         LOG.info(`Default from address defined as `, this._from);
     }
 
-    public static initialize ( config  ?: string ) {
+    public initialize ( config  ?: string ) {
 
         config = trim(config ?? '');
 
@@ -73,7 +86,7 @@ export class EmailService {
 
     }
 
-    public static async sendEmailMessage (message: EmailMessage) {
+    public async sendEmailMessage (message: EmailMessage) {
 
         const to : string[] | string = message?.to;
         const cc : string[] | string = message?.cc;
@@ -107,5 +120,3 @@ export class EmailService {
     }
 
 }
-
-

--- a/EmailVerificationService.ts
+++ b/EmailVerificationService.ts
@@ -1,10 +1,11 @@
 // Copyright (c) 2021-2022. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
 
 import { randomInt } from 'crypto';
-import { find, remove } from "../core/modules/lodash";
+import { filter, find, forEach, map, remove } from "../core/modules/lodash";
 import { LogService } from "../core/LogService";
+import { clearTimeout } from "timers";
 
-const VERIFICATION_TIMEOUT : number = 5*60*1000;
+const DEFAULT_VERIFICATION_TIMEOUT : number = 5*60*1000;
 
 interface InternalEmailCode {
     readonly code  : string;
@@ -16,91 +17,90 @@ const LOG = LogService.createLogger('EmailVerificationService');
 
 export class EmailVerificationService {
 
-    private static _codes : InternalEmailCode[] = [];
+    private _codes : InternalEmailCode[];
+    private readonly _verificationTimeout : number;
 
-    public static verifyCode (
+    public constructor (
+        verificationTimeout : number = DEFAULT_VERIFICATION_TIMEOUT
+    ) {
+        this._codes = [];
+        this._verificationTimeout = verificationTimeout;
+    }
+
+    public destroy () {
+        forEach(
+            this._codes,
+            (item: InternalEmailCode) => {
+                try {
+                    const timer = item?.timer;
+                    if (timer !== undefined) {
+                        clearTimeout(timer);
+                        item.timer = undefined;
+                    }
+                } catch (err) {
+                    LOG.error(`Could not remove timer: `, err);
+                }
+            }
+        );
+        this._codes = [];
+    }
+
+    public verifyCode (
         email : string,
         code  : string
     ) : boolean {
-
         LOG.debug(`verifyCode: "${code}" for email "${email}" `);
-
         if (!email) return false;
         if (!code) return false;
-
         const itemMatcher = (item : InternalEmailCode) => {
             return item?.email === email && item?.code === code;
         };
-
         const item : InternalEmailCode | undefined = find(this._codes, itemMatcher);
         if (!item) return false;
-
         if (item?.timer) {
             clearTimeout(item.timer);
             item.timer = undefined;
         }
-
         remove(this._codes, itemMatcher);
-
         LOG.debug(`Verified & removed "${code}" for email "${email}"`);
-
         return true;
-
     }
 
-    public static removeVerificationCode (
+    public removeVerificationCode (
         email : string,
         code  : string
     ) {
-
         if (!email) throw new TypeError('email is required');
         if (!code) throw new TypeError('code is required');
-
         const itemMatcher = (item : InternalEmailCode) => {
             return item.email === email && item.code === code;
         };
-
         const item : InternalEmailCode | undefined = find(this._codes, itemMatcher);
-
         if (item) {
-
             if (item?.timer) {
                 clearTimeout(item.timer);
                 item.timer = undefined;
             }
-
             remove(this._codes, itemMatcher);
-
             LOG.debug(`Removed "${code}" for email "${email}"`);
-
         }
-
     }
 
-    public static createVerificationCode (
+    public createVerificationCode (
         email: string
     ) : string {
-
         const code = `${randomInt(0, 9999)}`.padStart(4, "0");
-
         const timer = setTimeout(() => {
-            EmailVerificationService.removeVerificationCode(email, code);
-        }, VERIFICATION_TIMEOUT);
-
+            this.removeVerificationCode(email, code);
+        }, this._verificationTimeout);
         remove(this._codes, (item: InternalEmailCode) => item.email === email);
-
         this._codes.push({
             email,
             code,
             timer
         });
-
         LOG.debug(`Added "${code}" for email "${email}"`)
-
         return code;
-
     }
 
 }
-
-

--- a/JwtEngine.ts
+++ b/JwtEngine.ts
@@ -1,11 +1,11 @@
 // Copyright (c) 2021-2022. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
 
 import { ReadonlyJsonObject } from "../core/Json";
+import { JwtPayload } from "./types/JwtPayload";
 
 export interface JwtEngine {
     getDefaultAlgorithm () : string;
     setDefaultAlgorithm (value: string) : void;
-    sign(payload: ReadonlyJsonObject, alg?: string) : string;
+    sign(payload: ReadonlyJsonObject | JwtPayload, alg?: string) : string;
     verify(token: string, alg: string) : boolean;
 }
-

--- a/JwtService.ts
+++ b/JwtService.ts
@@ -10,14 +10,20 @@ const LOG = LogService.createLogger('JwtService');
 
 export class JwtService {
 
-    private static _defaultAlgorithm: string = 'HS256';
+    private _defaultAlgorithm: string;
 
-    public static getDefaultAlgorithm (): string {
-        return JwtService._defaultAlgorithm;
+    public constructor (
+        defaultAlgorithm: string = 'HS256'
+    ) {
+        this._defaultAlgorithm = defaultAlgorithm;
     }
 
-    public static setDefaultAlgorithm (value: string) {
-        JwtService._defaultAlgorithm = value;
+    public getDefaultAlgorithm (): string {
+        return this._defaultAlgorithm;
+    }
+
+    public setDefaultAlgorithm (value: string) {
+        this._defaultAlgorithm = value;
     }
 
     public static decodePayload (token: string) : ReadonlyJsonObject {
@@ -55,14 +61,20 @@ export class JwtService {
         return verified;
     }
 
-    public static createJwtEngine (
+    /**
+     * Creates a jwt engine which hides secret
+     *
+     * @param secret
+     * @param defaultAlgorithm
+     */
+    public createJwtEngine (
         secret: string,
         defaultAlgorithm ?: string
     ): JwtEngine {
         let _defaultAlgorithm: string | undefined = defaultAlgorithm;
         return {
             getDefaultAlgorithm: (): string => {
-                return _defaultAlgorithm ?? JwtService.getDefaultAlgorithm();
+                return _defaultAlgorithm ?? this.getDefaultAlgorithm();
             },
             setDefaultAlgorithm: (value: string): void => {
                 _defaultAlgorithm = value;
@@ -73,14 +85,14 @@ export class JwtService {
             ): string => {
                 return jwsSign(
                     {
-                        header: {alg: (alg ?? JwtService.getDefaultAlgorithm()) as unknown as Algorithm},
+                        header: {alg: (alg ?? this.getDefaultAlgorithm()) as unknown as Algorithm},
                         payload: payload,
                         secret: secret
                     }
                 );
             },
             verify: (token: string, alg?: string): boolean => {
-                return jwsVerify(token, (alg ?? _defaultAlgorithm ?? JwtService.getDefaultAlgorithm()) as unknown as Algorithm, secret);
+                return jwsVerify(token, (alg ?? _defaultAlgorithm ?? this.getDefaultAlgorithm()) as unknown as Algorithm, secret);
             }
         };
     }

--- a/JwtUtils.ts
+++ b/JwtUtils.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2022. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
+
+import { JwtPayload } from "./types/JwtPayload";
+
+export class JwtUtils {
+
+    public static calculateExpirationInDays (days: number) : number {
+        return Math.floor(Date.now() / 1000 + days * 24 * 60 * 60);
+    }
+
+    public static calculateExpirationInMinutes (minutes: number) : number {
+        return Math.floor(Date.now() / 1000 + minutes * 60);
+    }
+
+    public static createAudPayloadExpiringInDays (
+        aud: string,
+        days: number
+    ) : JwtPayload {
+        return {
+            exp: JwtUtils.calculateExpirationInDays(days),
+            aud
+        };
+    }
+
+    public static createAudPayloadExpiringInMinutes (
+        aud: string,
+        minutes: number
+    ) : JwtPayload {
+        return {
+            exp: JwtUtils.calculateExpirationInMinutes(minutes),
+            aud
+        };
+    }
+
+    public static createSubPayloadExpiringInDays (
+        sub: string,
+        days: number
+    ) : JwtPayload {
+        return {
+            exp: JwtUtils.calculateExpirationInDays(days),
+            sub
+        };
+    }
+
+    public static createSubPayloadExpiringInMinutes (
+        sub: string,
+        minutes: number
+    ) : JwtPayload {
+        return {
+            exp: JwtUtils.calculateExpirationInMinutes(minutes),
+            sub
+        };
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
 # fi.hg.backend
 
-Backend module
+HG Backend module
 
 ### Install the module
 
+This module depends on `nodemailer`, `i18next` and `jws` modules:
+
 ```shell
-npm i '@types/lodash' lodash
-hgm i fi.hg.core
-hgm i fi.hg.backend
+npm i '@types/i18next' i18next '@types/nodemailer' nodemailer '@types/jws' jws
 ```
 
-### EmailAuthController
+Our [fi.hg.core](https://github.com:heusalagroup/fi.hg.core) is also required dependency:
+
+```shell
+mkdir -p src/fi/hg
+git submodule add git@github.com:heusalagroup/fi.hg.core.git src/fi/hg/core
+git config -f .gitmodules submodule.src/fi/hg/core.branch main
+```
+
+Finally, you can set up the module itself:
+
+```shell
+git submodule add git@github.com:heusalagroup/fi.hg.backend.git src/fi/hg/backend
+git config -f .gitmodules submodule.src/fi/hg/backend.branch main
+```
+
+See also [@heusalagroup/create-backend](https://github.com/heusalagroup/create-backend) for how to initialize your own backend project.
+
+### `EmailAuthController`
 
 You can use the `EmailAuthController` in your HTTP controller as follows:
 
@@ -79,17 +96,3 @@ async function main () {
 ```
 
 See [hg-email-auth](https://github.com/heusalagroup/hg-email-auth) for how to use the service.
-
-#### Installation
-
-This service depends on `nodemailer`, `i18next` and `jws` modules as well as [hgm's](https://github.com/heusalagroup/hgm) submodule [fi.hg.auth.email](https://github.com/heusalagroup/fi.hg.auth.email):
-
-```shell
-npm i '@types/i18next' i18next
-npm i '@types/nodemailer' nodemailer
-npm i '@types/jws' jws
-hgm i fi.hg.auth.email
-```
-
-See also [@heusalagroup/create-backend](https://github.com/heusalagroup/create-backend) for how to initialize your own backend project.
-

--- a/types/JwtPayload.ts
+++ b/types/JwtPayload.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2022. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
+
+import { hasNoOtherKeys, isNumberOrUndefined, isRegularObject, isStringOrUndefined } from "../../core/modules/lodash";
+
+export interface JwtPayload {
+
+    /**
+     * Expiration time
+     * @see https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.4
+     */
+    readonly exp ?: number;
+
+    /**
+     * Audience, e.g. the recipient(s) who this JWT is intended for.
+     * @see https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3
+     */
+    readonly aud ?: string;
+
+    /**
+     * Subject, e.g. the subject of the JWT.
+     * @see https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.2
+     */
+    readonly sub ?: string;
+
+}
+
+export function createJwtPayload (
+    exp ?: number,
+    aud ?: string,
+    sub ?: string
+): JwtPayload {
+    return {
+        exp,
+        aud,
+        sub
+    };
+}
+
+export function isJwtPayload (value: any): value is JwtPayload {
+    return (
+        isRegularObject(value)
+        && hasNoOtherKeys(value, [
+            'exp',
+            'aud',
+            'sub'
+        ])
+        && isNumberOrUndefined(value?.exp)
+        && isStringOrUndefined(value?.aud)
+        && isStringOrUndefined(value?.sub)
+    );
+}
+
+export function stringifyJwtPayload (value: JwtPayload): string {
+    return `JwtPayload(${value})`;
+}
+
+export function parseJwtPayload (value: any): JwtPayload | undefined {
+    if ( isJwtPayload(value) ) return value;
+    return undefined;
+}


### PR DESCRIPTION
Changes made for [hghs](https://github.com/heusalagroup/hghs) development.

This PR includes breaking changes that require changes in the client code.

We have changed most of the services that had internal state as real classes now.

This means, for example, `EmailService` cannot be used directly using static methods. 

You have to create your own instance of the service first and provide it to any service that needs it. Usually this is done in the `main.ts`.

```
const emailService = new EmailService(fromAddress);
```

This makes it possible to configure different services with different configurations inside the same server process. Much more flexible than using static API. It's also easier to create interfaces and different implementations.